### PR TITLE
Generic Kafka Consumer Does Not Require Username

### DIFF
--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -66,7 +66,6 @@ class Consumer (threading.Thread):
                                           group_id=self.trigger,
                                           client_id="openwhisk",
                                           bootstrap_servers=self.brokers,
-                                          sasl_plain_username=self.username,
                                           auto_offset_reset="latest",
                                           enable_auto_commit=False)
 


### PR DESCRIPTION
- Remove username when initializing generic Kafka consumer
- Fixes https://github.com/openwhisk/openwhisk-package-kafka/issues/3