### PR TITLE
return promise in feed action

### DIFF
--- a/action/feedAction.js
+++ b/action/feedAction.js
@@ -80,6 +80,8 @@ function doRequest(options) {
             }
         });
     });
+
+    return promise;
 }
 
 function validateParameters(rawParams) {


### PR DESCRIPTION
The feed action does not actually return the Promise created in the `doRequest` function. This causes the feed action to always immediately "succeed" even when things go horribly wrong.