### PR TITLE
Keep track of each consumer's last successful poll

### DIFF
--- a/provider/app.py
+++ b/provider/app.py
@@ -89,10 +89,24 @@ def testRoute():
 
 @app.route('/health')
 def healthRoute():
+    healthReport = {}
+
     currentTime = datetime.now()
     delta = currentTime - startTime
     uptimeSeconds = int(round(delta.total_seconds()))
-    return jsonify({'uptime': uptimeSeconds})
+    healthReport['uptime'] = uptimeSeconds
+
+    consumerReports = []
+    for consumerId in consumers:
+        consumer = consumers[consumerId]
+        lastPollDelta = currentTime - consumer.lastPoll
+        consumerInfo = {}
+        consumerInfo[consumerId] = {'secondsSinceLastPoll': lastPollDelta.total_seconds()}
+        consumerReports.append(consumerInfo)
+
+    healthReport['consumers'] = consumerReports
+
+    return jsonify(healthReport)
 
 
 def authorizedForTrigger(auth, consumer):

--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -19,6 +19,7 @@ import ssl
 import threading
 import time
 from database import Database
+from datetime import datetime
 from kafka import KafkaConsumer, KafkaProducer
 from kafka.errors import KafkaError
 from kafka.structs import OffsetAndMetadata
@@ -40,6 +41,8 @@ class Consumer (threading.Thread):
         self.topic = params["topic"]
         self.username = params["username"]
         self.password = params["password"]
+
+        self.lastPoll = datetime.max
 
         # handle the case where there may be existing triggers that do not
         # have the isJSONData field set
@@ -143,6 +146,8 @@ class Consumer (threading.Thread):
                                 len(messages), message.offset, message.partition))
                             self.consumer.commit()
                             retry = False
+
+            self.lastPoll = datetime.now()
 
         if not self.shouldRun:
             logging.info("[{}] Consumer exiting main loop".format(self.trigger))


### PR DESCRIPTION
This will be reported in the `/health` endpoint as seconds elapsed since each consumer's last successful poll. Presumably, a high value will indicate that a consumer has died, a negative value indicates the consumer has not fully initialized.
