### PR TITLE
use a "real" WSGI server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,13 @@ FROM python:2.7.12-alpine
 
 # Upgrade and install basic Python dependencies
 RUN apk add --no-cache bash \
-    && pip install --no-cache-dir flask==0.11.1 kafka_python==1.3.1 requests==2.10.0 cloudant==2.1.0
+    && apk add --no-cache --virtual .build-deps \
+        bzip2-dev \
+        gcc \
+        libc-dev \
+    && pip install --no-cache-dir gevent==1.1.2 flask==0.11.1 kafka_python==1.3.1 requests==2.10.0 cloudant==2.1.0
 
-ENV FLASK_PROXY_PORT 8080
+ENV PORT 5000
 
 RUN mkdir -p /KafkaFeedProvider
 ADD provider/*.py /KafkaFeedProvider/

--- a/provider/app.py
+++ b/provider/app.py
@@ -20,8 +20,10 @@ from consumer import Consumer
 from database import Database
 from urlparse import urlparse
 import requests
+from gevent.wsgi import WSGIServer
 
 app = Flask(__name__)
+app.debug = False
 database = Database()
 
 consumers = dict()
@@ -120,10 +122,16 @@ def restoreTriggers():
         logging.info('Restoring trigger {}'.format(triggerFQN))
         createAndRunConsumer(triggerFQN, triggerDoc, record=False)
 
-port = os.getenv('PORT', '5000')
-if __name__ == "__main__":
-    startTime = datetime.now()
+
+def main():
     logging.basicConfig(
         format='%(asctime)s [%(levelname)s]: %(message)s', level=logging.INFO)
     restoreTriggers()
-    app.run(host='0.0.0.0', port=int(port))
+
+    port = int(os.getenv('PORT', 5000))
+    server = WSGIServer(('', port), app, log=None)
+    server.serve_forever()
+
+if __name__ == '__main__':
+    startTime = datetime.now()
+    main()

--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -154,7 +154,8 @@ class Consumer (threading.Thread):
     def shutdown(self):
         logging.info("[{}] Shutting down consumer for trigger".format(self.trigger))
         self.shouldRun = False
-        self.join()
+        database = Database()
+        database.deleteTrigger(self.trigger)
 
     def parseMessageIfNeeded(self, value):
         if self.parseAsJson:


### PR DESCRIPTION
The server included with Flask is generally considered a "toy" that should not be used for production apps. Instead, let's use the WSGI server in gevent.