### PR TITLE
Set post timeout to a reasonable amount of time

### DIFF
--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -299,7 +299,7 @@ class ConsumerThread (Thread):
 
             while not success and retry:
                 try:
-                    response = requests.post(self.triggerURL, json=payload)
+                    response = requests.post(self.triggerURL, json=payload, timeout=10.0)
                     status_code = response.status_code
                     logging.info("[{}] Repsonse status code {}".format(self.trigger, status_code))
 


### PR DESCRIPTION
Otherwise, it can take painfully long for a request to timeout. This runs the risk of poll() taking too long and the consumer being considered dead, which causes automatic rebalancing and all kinds of other bad side effects.

Resolves #60 