### PR TITLE
Do not Assume all Fields are Provided when a Trigger is Posted

### DIFF
--- a/provider/app.py
+++ b/provider/app.py
@@ -41,6 +41,7 @@ def postTrigger(namespace, trigger):
     body = request.get_json(force=True, silent=True)
     triggerFQN = '/' + namespace + '/' + trigger
     expectedRoute = urllib.quote('/namespaces/' + namespace + '/triggers/' + trigger)
+    missing = getMissingPostFields(body)
 
     if consumers.hasConsumerForTrigger(triggerFQN):
         logging.warn("[{}] Trigger already exists".format(triggerFQN))
@@ -49,6 +50,13 @@ def postTrigger(namespace, trigger):
             'error': "trigger already exists"
         })
         response.status_code = 409
+    elif len(missing) > 0:
+        response = jsonify({
+            'success': False,
+            'error': 'missing fields: %s' % ', '.join(missing)
+        })
+        response.status_code = 400
+        return response
     elif not body["triggerURL"].endswith(expectedRoute):
         logging.warn("[{}] Trigger and namespace from route must correspond to triggerURL".format(triggerFQN))
         response = jsonify({
@@ -140,6 +148,25 @@ def restoreTriggers():
         triggerFQN = triggerDoc['_id']
         logging.debug('Restoring trigger {}'.format(triggerFQN))
         createAndRunConsumer(triggerFQN, triggerDoc, record=False)
+
+
+def getMissingPostFields(fields):
+    missing = []
+    messageHubRequired = ['brokers', 'topic', 'triggerURL', 'isMessageHub', 'username', 'password']
+    kafkaRequired = ['brokers', 'topic', 'triggerURL', 'isMessageHub']
+
+    if fields is None:
+        missing.extend(kafkaRequired)
+    else:
+        if 'isMessageHub' in fields and fields['isMessageHub'] == True:
+            missing.extend([i for i in messageHubRequired if i not in fields])
+        else:
+            missing.extend([i for i in kafkaRequired if i not in fields])
+
+    if len(missing) > 0:
+        logging.info("Required fields are missing {}".format(missing))
+
+    return missing
 
 
 def main():

--- a/provider/app.py
+++ b/provider/app.py
@@ -152,16 +152,16 @@ def restoreTriggers():
 
 def getMissingPostFields(fields):
     missing = []
-    messageHubRequired = ['brokers', 'topic', 'triggerURL', 'isMessageHub', 'username', 'password']
-    kafkaRequired = ['brokers', 'topic', 'triggerURL', 'isMessageHub']
+    requiredFields = ['brokers', 'topic', 'triggerURL', 'isMessageHub']
+
+    # Message Hub also requires 'username' and 'password fields'
+    if 'isMessageHub' in fields and fields['isMessageHub'] == True:
+        requiredFields.extend(['username', 'password'])
 
     if fields is None:
-        missing.extend(kafkaRequired)
+        missing.extend(requiredFields)
     else:
-        if 'isMessageHub' in fields and fields['isMessageHub'] == True:
-            missing.extend([i for i in messageHubRequired if i not in fields])
-        else:
-            missing.extend([i for i in kafkaRequired if i not in fields])
+        missing.extend([i for i in requiredFields if i not in fields])
 
     if len(missing) > 0:
         logging.info("Required fields are missing {}".format(missing))

--- a/provider/app.py
+++ b/provider/app.py
@@ -154,13 +154,13 @@ def getMissingPostFields(fields):
     missing = []
     requiredFields = ['brokers', 'topic', 'triggerURL', 'isMessageHub']
 
-    # Message Hub also requires 'username' and 'password fields'
-    if 'isMessageHub' in fields and fields['isMessageHub'] == True:
-        requiredFields.extend(['username', 'password'])
-
     if fields is None:
         missing.extend(requiredFields)
     else:
+        # Message Hub also requires 'username' and 'password fields'
+        if 'isMessageHub' in fields and fields['isMessageHub'] == True:
+            requiredFields.extend(['username', 'password'])
+
         missing.extend([i for i in requiredFields if i not in fields])
 
     if len(missing) > 0:

--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -120,8 +120,10 @@ class ConsumerThread (Thread):
         self.triggerURL = params["triggerURL"]
         self.brokers = params["brokers"]
         self.topic = params["topic"]
-        self.username = params["username"]
-        self.password = params["password"]
+
+        if self.isMessageHub:
+            self.username = params["username"]
+            self.password = params["password"]
 
         # handle the case where there may be existing triggers that do not
         # have the isJSONData field set


### PR DESCRIPTION
- Ensure all needed fields are received from the client when posting a trigger
- Return an error JSON payload if proper fields are not received
- Don't error in Consumer if isMessageHub is set to false and credentials are not providedi