### PR TITLE
Make generic kafka functionality optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN pip install gevent==1.1.2 flask==0.11.1 confluent-kafka==0.9.2 \
 # set reasonable defaults
 ENV PORT 5000
 ENV LOCAL_DEV False
+ENV GENERIC_KAFKA True
 
 RUN mkdir -p /KafkaFeedProvider
 ADD provider/*.py /KafkaFeedProvider/

--- a/provider/app.py
+++ b/provider/app.py
@@ -66,6 +66,14 @@ def postTrigger(namespace, trigger):
             'error': "trigger and namespace from route must correspond to triggerURL"
         })
         response.status_code = 409
+    elif not body["isMessageHub"] and not enable_generic_kafka:
+        # Generic Kafka triggers has been disabled
+        logging.warn("[{}] Attempt to create generic kafka trigger while function is disabled".format(triggerFQN))
+        response = jsonify({
+            'success': False,
+            'error': "Only triggers for Message Hub instances are allowed."
+        })
+        response.status_code = 403
     else:
         logging.info("[{}] Ensuring user has access rights to post a trigger".format(triggerFQN))
         trigger_get_response = requests.get(body["triggerURL"], verify=check_ssl)
@@ -198,6 +206,12 @@ def main():
     global check_ssl
     check_ssl = (local_dev == 'False')
     logging.info('check_ssl is {} {}'.format(check_ssl, type(check_ssl)))
+
+    generic_kafka = os.getenv('GENERIC_KAFKA', 'True')
+    logging.debug('GENERIC_KAFKA is {} {}'.format(generic_kafka, type(generic_kafka)))
+    global enable_generic_kafka
+    enable_generic_kafka = (generic_kafka == 'True')
+    logging.info('enable_generic_kafka is {} {}'.format(enable_generic_kafka, type(enable_generic_kafka)))
 
     database.migrate()
 


### PR DESCRIPTION
Use an environment variable named `GENERIC_KAFKA` to control whether triggers can be created for unauthenticated Kafka instances. If the value is set to "True" generic Kafka triggers will be permitted. Any other values will result in a 403 response when attempting to create such triggers.