### PR TITLE
Handle the case where params.endpoint already contains the protocol

### DIFF
--- a/action/kafkaFeed.js
+++ b/action/kafkaFeed.js
@@ -33,7 +33,10 @@ function main(params) {
         }
 
         var body = validatedParams;
-        body.triggerURL = 'https://' + whisk.getAuthKey() + "@" + params.endpoint + '/api/v1/namespaces/' + namespace + '/triggers/' + trigger;
+        // params.endpoint may already include the protocol - if so,
+        // strip it out
+        var massagedAPIHost = massageAPIHost(params.endpoint);
+        body.triggerURL = 'https://' + whisk.getAuthKey() + "@" + massagedAPIHost + '/api/v1/namespaces/' + namespace + '/triggers/' + trigger;
 
         var options = {
             method: 'PUT',
@@ -119,4 +122,14 @@ function validateParameters(rawParams) {
 
 function isNonEmptyArray(obj) {
     return obj && Array.isArray(obj) && obj.length !== 0;
+}
+
+// if the apiHost already includes the protocol, remove it
+function massageAPIHost(apiHost) {
+    if(apiHost.substr(0, 4) === 'http') {
+        // the apiHost includes the protocol - strip it out
+        return apiHost.split('/')[2]
+    } else {
+        return apiHost;
+    }
 }

--- a/action/kafkaFeed.js
+++ b/action/kafkaFeed.js
@@ -35,7 +35,7 @@ function main(params) {
         var body = validatedParams;
         // params.endpoint may already include the protocol - if so,
         // strip it out
-        var massagedAPIHost = massageAPIHost(params.endpoint);
+        var massagedAPIHost = params.endpoint.replace(/https?:\/\/(.*)/, "$1");
         body.triggerURL = 'https://' + whisk.getAuthKey() + "@" + massagedAPIHost + '/api/v1/namespaces/' + namespace + '/triggers/' + trigger;
 
         var options = {
@@ -122,14 +122,4 @@ function validateParameters(rawParams) {
 
 function isNonEmptyArray(obj) {
     return obj && Array.isArray(obj) && obj.length !== 0;
-}
-
-// if the apiHost already includes the protocol, remove it
-function massageAPIHost(apiHost) {
-    if(apiHost.substr(0, 4) === 'http') {
-        // the apiHost includes the protocol - strip it out
-        return apiHost.split('/')[2]
-    } else {
-        return apiHost;
-    }
 }

--- a/action/messageHubFeed.js
+++ b/action/messageHubFeed.js
@@ -44,7 +44,7 @@ function main(params) {
 
                 // params.endpoint may already include the protocol - if so,
                 // strip it out
-                var massagedAPIHost = massageAPIHost(params.endpoint);
+                var massagedAPIHost = params.endpoint.replace(/https?:\/\/(.*)/, "$1");
                 body.triggerURL = 'https://' + whisk.getAuthKey() + "@" + massagedAPIHost + '/api/v1/namespaces/' + namespace + '/triggers/' + trigger;
 
                 var options = {
@@ -201,14 +201,4 @@ function validateBrokerParam(brokerParam) {
 
 function isNonEmptyArray(obj) {
     return obj && Array.isArray(obj) && obj.length !== 0;
-}
-
-// if the apiHost already includes the protocol, remove it
-function massageAPIHost(apiHost) {
-    if(apiHost.substr(0, 4) === 'http') {
-        // the apiHost includes the protocol - strip it out
-        return apiHost.split('/')[2]
-    } else {
-        return apiHost;
-    }
 }

--- a/action/messageHubFeed.js
+++ b/action/messageHubFeed.js
@@ -41,7 +41,11 @@ function main(params) {
                 console.log("Successfully authenticated with Message Hub");
 
                 var body = validatedParams;
-                body.triggerURL = 'https://' + whisk.getAuthKey() + "@" + params.endpoint + '/api/v1/namespaces/' + namespace + '/triggers/' + trigger;
+
+                // params.endpoint may already include the protocol - if so,
+                // strip it out
+                var massagedAPIHost = massageAPIHost(params.endpoint);
+                body.triggerURL = 'https://' + whisk.getAuthKey() + "@" + massagedAPIHost + '/api/v1/namespaces/' + namespace + '/triggers/' + trigger;
 
                 var options = {
                     method: 'PUT',
@@ -197,4 +201,14 @@ function validateBrokerParam(brokerParam) {
 
 function isNonEmptyArray(obj) {
     return obj && Array.isArray(obj) && obj.length !== 0;
+}
+
+// if the apiHost already includes the protocol, remove it
+function massageAPIHost(apiHost) {
+    if(apiHost.substr(0, 4) === 'http') {
+        // the apiHost includes the protocol - strip it out
+        return apiHost.split('/')[2]
+    } else {
+        return apiHost;
+    }
 }


### PR DESCRIPTION
If the protocol already exists, remove it so that the trigger URL can be properly constructed.

Resolves #93 