### PR TITLE
Ensure that the selected namespace is actually valid

### DIFF
--- a/tests/src/system/health/MessagingFeedTests.scala
+++ b/tests/src/system/health/MessagingFeedTests.scala
@@ -64,7 +64,8 @@ class MessagingFeedTests
     val messageHubFeed = "messageHubFeed"
 
     def getNonDefaultNamespace(): String = {
-        wsk.namespace.list().stdout.trim.split("\n").last
+        val allNamespaces = wsk.namespace.list().stdout.trim.split("\n").drop(1)
+        allNamespaces.filter(_.indexOf('\'') < 0).head
     }
 
     def setMessageHubSecurityConfiguration(user: String, password: String) = {
@@ -85,6 +86,7 @@ class MessagingFeedTests
 
     it should "fire a trigger when a message is posted to the message hub" in withAssetCleaner(wskprops) {
         val nondefaultNamespace = getNonDefaultNamespace()
+        println(s"I chose namespace: ${nondefaultNamespace}")
         var credentials = TestUtils.getCredentials("message_hub")
         val user = credentials.get("user").getAsString()
         val password = credentials.get("password").getAsString()


### PR DESCRIPTION
In certain scenarios, not all namespaces for an account are actually valid. This code attempts to filter out the namespace selection to not include invalid namespaces.