### PR TITLE
remove use of deprecated whisk object

### DIFF
--- a/action/kafkaFeed.js
+++ b/action/kafkaFeed.js
@@ -27,7 +27,7 @@ function main(params) {
                 // params.endpoint may already include the protocol - if so,
                 // strip it out
                 var massagedAPIHost = params.endpoint.replace(/https?:\/\/(.*)/, "$1");
-                body.triggerURL = 'https://' + whisk.getAuthKey() + "@" + massagedAPIHost + '/api/v1/namespaces/' + namespace + '/triggers/' + trigger;
+                body.triggerURL = 'https://' + process.env['__OW_API_KEY'] + "@" + massagedAPIHost + '/api/v1/namespaces/' + namespace + '/triggers/' + trigger;
 
                 var options = {
                     method: 'PUT',
@@ -47,7 +47,7 @@ function main(params) {
                 .then(resolve)
                 .catch(reject);
         } else if (params.lifecycleEvent === 'DELETE') {
-            var authorizationHeader = 'Basic ' + new Buffer(whisk.getAuthKey()).toString('base64');
+            var authorizationHeader = 'Basic ' + new Buffer(process.env['__OW_API_KEY']).toString('base64');
 
             var options = {
                 method: 'DELETE',

--- a/action/messageHubFeed.js
+++ b/action/messageHubFeed.js
@@ -29,7 +29,7 @@ function main(params) {
                 // params.endpoint may already include the protocol - if so,
                 // strip it out
                 var massagedAPIHost = params.endpoint.replace(/https?:\/\/(.*)/, "$1");
-                body.triggerURL = 'https://' + whisk.getAuthKey() + "@" + massagedAPIHost + '/api/v1/namespaces/' + namespace + '/triggers/' + trigger;
+                body.triggerURL = 'https://' + process.env['__OW_API_KEY'] + "@" + massagedAPIHost + '/api/v1/namespaces/' + namespace + '/triggers/' + trigger;
 
                 var options = {
                     method: 'PUT',
@@ -50,7 +50,7 @@ function main(params) {
                 .then(resolve)
                 .catch(reject);
         } else if (params.lifecycleEvent === 'DELETE') {
-            var authorizationHeader = 'Basic ' + new Buffer(whisk.getAuthKey()).toString('base64');
+            var authorizationHeader = 'Basic ' + new Buffer(process.env['__OW_API_KEY']).toString('base64');
 
             var options = {
                 method: 'DELETE',


### PR DESCRIPTION
There are two uses of of the (soon-to-be-removed) whisk object: `whisk.error()` and `whisk.getAuthKey()`

`whisk.error()` is replaced with promise rejection, and `whisk.getAuthKey()` is replaced with the `__OW_API_KEY` environment variable. Promise rejection required a little bit of refactoring to make it work nicely.

Resolves #98 