### PR TITLE
Increase timeout for docker HEALTHCHECK instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,6 @@ ADD provider/*.py /KafkaFeedProvider/
 # If the endpoint doesn't respond within 30 seconds, kill the main python process.
 # As of docker 1.12, a failed healthcheck never results in the container being
 # restarted. Killing the main process is a way to make the restart policy kicks in.
-HEALTHCHECK --interval=5m CMD curl -m 30 --fail http://localhost:5000/health || killall python
+HEALTHCHECK --interval=5m --timeout=1m CMD curl -m 30 --fail http://localhost:5000/health || killall python
 
 CMD ["/bin/bash", "-c", "cd KafkaFeedProvider && python -u app.py"]


### PR DESCRIPTION
The default timeout is 30 seconds. When pared with the curl command's explicit timeout of (also) 30 seconds, it seems that Docker kills the health check just before curl has a chance to fail and cause the container to restart. Explicitly increasing the timeout for the HEALTHCHECK instruction avoids this problem.