### PR TITLE
Fix tests

### DIFF
--- a/tests/src/system/health/MessagingFeedTests.scala
+++ b/tests/src/system/health/MessagingFeedTests.scala
@@ -16,15 +16,11 @@
 
 package system.health
 
-import java.util.HashMap
-import java.util.Properties
-import javax.security.auth.login.Configuration
-import javax.security.auth.login.AppConfigurationEntry
+import system.utils.KafkaUtils
 
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
 
-import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterAll
@@ -34,14 +30,11 @@ import org.scalatest.junit.JUnitRunner
 
 import common.JsHelpers
 import common.TestHelpers
-import common.TestUtils
 import common.Wsk
 import common.WskActorSystem
 import common.WskProps
 import common.WskTestHelpers
-import spray.json.DefaultJsonProtocol.StringJsonFormat
-import spray.json.JsArray
-import spray.json.JsString
+import spray.json.DefaultJsonProtocol._
 import spray.json.pimpAny
 
 @RunWith(classOf[JUnitRunner])
@@ -63,59 +56,23 @@ class MessagingFeedTests
     val messagingPackage = "/whisk.system/messaging"
     val messageHubFeed = "messageHubFeed"
 
-    def setMessageHubSecurityConfiguration(user: String, password: String) = {
-        val map = new HashMap[String, String]()
-        map.put("serviceName", "kafka")
-        map.put("username", user)
-        map.put("password", password)
-        Configuration.setConfiguration(new Configuration()
-        {
-            def getAppConfigurationEntry(name: String): Array[AppConfigurationEntry] = Array(
-    	          new AppConfigurationEntry (
-    	              "com.ibm.messagehub.login.MessageHubLoginModule",
-     			          AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, map))
-        })
-    }
+    val kafkaUtils = new KafkaUtils
 
     behavior of "Message Hub"
 
     it should "fire a trigger when a message is posted to the message hub" in withAssetCleaner(wskprops) {
-        var credentials = TestUtils.getCredentials("message_hub")
-        val user = credentials.get("user").getAsString()
-        val password = credentials.get("password").getAsString()
-        val kafka_admin_url = credentials.get("kafka_admin_url").getAsString()
-        val api_key = credentials.get("api_key").getAsString()
-        val kafka_brokers_sasl_json_array = credentials.get("kafka_brokers_sasl").getAsJsonArray()
-
-        var vec = Vector[JsString]()
-        var servers = s""
-        val iter = kafka_brokers_sasl_json_array.iterator();
-        while(iter.hasNext()){
-            val server = iter.next().getAsString()
-            vec = vec :+ JsString(server)
-            servers = s"$servers$server,"
-        }
-        var kafka_brokers_sasl = JsArray(vec)
-
         val currentTime = s"${System.currentTimeMillis}"
-        System.setProperty("java.security.auth.login.config", "")
-        setMessageHubSecurityConfiguration(user, password)
-        var props = new Properties()
-        props.put("bootstrap.servers", servers);
-        props.put("security.protocol", "SASL_SSL");
-        props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
-        props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
 
         (wp, assetHelper) =>
             val triggerName = s"/_/dummyMessageHubTrigger-$currentTime"
             val feedCreationResult = assetHelper.withCleaner(wsk.trigger, triggerName) {
                 (trigger, _) =>
                     trigger.create(triggerName, feed = Some(s"$messagingPackage/$messageHubFeed"), parameters = Map(
-                        "user" -> user.toJson,
-                        "password" -> password.toJson,
-                        "api_key" -> api_key.toJson,
-                        "kafka_admin_url" -> kafka_admin_url.toJson,
-                        "kafka_brokers_sasl" -> kafka_brokers_sasl,
+                        "user" -> kafkaUtils("user").asInstanceOf[String].toJson,
+                        "password" -> kafkaUtils("password").asInstanceOf[String].toJson,
+                        "api_key" -> kafkaUtils("api_key").asInstanceOf[String].toJson,
+                        "kafka_admin_url" -> kafkaUtils("kafka_admin_url").asInstanceOf[String].toJson,
+                        "kafka_brokers_sasl" -> kafkaUtils("brokers").asInstanceOf[List[String]].toJson,
                         "topic" -> topic.toJson))
             }
             withActivation(wsk.activation, feedCreationResult, initialWait = 5 seconds, totalWait = 60 seconds) {
@@ -127,13 +84,15 @@ class MessagingFeedTests
             // It takes a moment for the consumer to fully initialize. We choose 2 seconds
             // as a temporary length of time to wait for.
             Thread.sleep(2000)
-            val producer = new KafkaProducer[String, String](props)
+
+            val producer = kafkaUtils.createProducer()
             val record = new ProducerRecord(topic, "key", currentTime)
             producer.send(record)
             producer.close()
             val activations = wsk.activation.pollFor(N = 2, Some(triggerName), retries = 30)
             var triggerFired = false
             assert(activations.length > 0)
+
             for (id <- activations) {
                 val activation = wsk.activation.waitForActivation(id)
                 if (activation.isRight) {

--- a/tests/src/system/health/MessagingFeedTests.scala
+++ b/tests/src/system/health/MessagingFeedTests.scala
@@ -35,6 +35,8 @@ import common.WskActorSystem
 import common.WskProps
 import common.WskTestHelpers
 import spray.json.DefaultJsonProtocol._
+import spray.json.JsArray
+import spray.json.JsObject
 import spray.json.pimpAny
 
 @RunWith(classOf[JUnitRunner])
@@ -58,9 +60,9 @@ class MessagingFeedTests
 
     val kafkaUtils = new KafkaUtils
 
-    behavior of "Message Hub"
+    behavior of "Message Hub feed"
 
-    it should "fire a trigger when a message is posted to the message hub" in withAssetCleaner(wskprops) {
+    it should "fire a trigger when a message is posted to message hub" in withAssetCleaner(wskprops) {
         val currentTime = s"${System.currentTimeMillis}"
 
         (wp, assetHelper) =>
@@ -75,6 +77,7 @@ class MessagingFeedTests
                         "kafka_brokers_sasl" -> kafkaUtils("brokers").asInstanceOf[List[String]].toJson,
                         "topic" -> topic.toJson))
             }
+
             withActivation(wsk.activation, feedCreationResult, initialWait = 5 seconds, totalWait = 60 seconds) {
                 activation =>
                     // should be successful
@@ -89,19 +92,33 @@ class MessagingFeedTests
             val record = new ProducerRecord(topic, "key", currentTime)
             producer.send(record)
             producer.close()
+
             val activations = wsk.activation.pollFor(N = 2, Some(triggerName), retries = 30)
-            var triggerFired = false
             assert(activations.length > 0)
 
-            for (id <- activations) {
-                val activation = wsk.activation.waitForActivation(id)
-                if (activation.isRight) {
-                    // Check if the trigger is fired with the specific message, which is the current time
-                    // generated.
-                    if (activation.right.get.fields.get("response").toString.contains(currentTime))
-                        triggerFired = true
-                }
-            }
-            assert(triggerFired == true)
+            val matchingActivations = for {
+                id <- activations
+                activation = wsk.activation.waitForActivation(id)
+                if (activation.isRight && activation.right.get.fields.get("response").toString.contains(currentTime))
+            } yield activation.right.get
+
+            assert(matchingActivations.length == 1)
+
+            val activation = matchingActivations.head
+            activation.getFieldPath("response", "success") shouldBe Some(true.toJson)
+
+            // assert that there exists a message in the activation which has the expected keys and values
+            val messages = messagesInActivation(activation, withMessageValue = currentTime)
+            assert(messages.length == 1)
+
+            val message = messages.head
+            message.getFieldPath("topic") shouldBe Some(topic.toJson)
+    }
+
+    def messagesInActivation(activation : JsObject, withMessageValue: String) : Array[JsObject] = {
+        val messages = activation.getFieldPath("response", "result", "messages").getOrElse(JsArray.empty).convertTo[Array[JsObject]]
+        messages.filter {
+            _.getFieldPath("value") == Some(withMessageValue.toJson)
+        }
     }
 }

--- a/tests/src/system/utils/KafkaUtils.scala
+++ b/tests/src/system/utils/KafkaUtils.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.utils
+
+import common.TestUtils
+
+import java.util.HashMap
+import java.util.Properties
+import javax.security.auth.login.Configuration
+import javax.security.auth.login.AppConfigurationEntry
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+
+import scala.collection.mutable.ListBuffer
+
+
+class KafkaUtils {
+    lazy val messageHubProps = KafkaUtils.initializeMessageHub()
+
+    def createProducer() : KafkaProducer[String, String] = {
+        // currently only supporting MH
+        new KafkaProducer[String, String](KafkaUtils.asKafkaProducerProps(this.messageHubProps))
+    }
+
+    def apply(key : String) = {
+        this.messageHubProps.getOrElse(key, "")
+    }
+}
+
+object KafkaUtils {
+    def asKafkaProducerProps(props : Map[String,Object]) : Properties = {
+        val requiredKeys = List("brokers",
+                                "user",
+                                "password",
+                                "key.serializer",
+                                "value.serializer",
+                                "security.protocol")
+
+        val propertyMap = props.filterKeys(
+            requiredKeys.contains(_)
+        ).map(
+            tuple =>
+                tuple match {
+                    // transform "brokers" key to "bootstrap.servers"
+                    case (k, v) if k == "brokers" => ("bootstrap.servers", v.asInstanceOf[List[String]].mkString(","))
+                    case _ => tuple
+                }
+        )
+
+        val kafkaProducerProps = new Properties()
+        for ((k, v) <- propertyMap) kafkaProducerProps.put(k, v)
+
+        kafkaProducerProps
+    }
+
+    private def initializeMessageHub() = {
+        // get the vcap stuff
+        var credentials = TestUtils.getCredentials("message_hub")
+
+        // initialize the set of tuples to go into the resulting Map
+        val user = ("user", credentials.get("user").getAsString())
+        val password = ("password", credentials.get("password").getAsString())
+        val kafka_admin_url = ("kafka_admin_url", credentials.get("kafka_admin_url").getAsString())
+        val api_key = ("api_key", credentials.get("api_key").getAsString())
+        val security_protocol = ("security.protocol", "SASL_SSL");
+        val keySerializer = ("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        val valueSerializer = ("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+
+        var brokerList = new ListBuffer[String]()
+        val jsonArray = credentials.get("kafka_brokers_sasl").getAsJsonArray()
+        val brokerIterator = jsonArray.iterator()
+        while(brokerIterator.hasNext()) {
+            val current = brokerIterator.next().getAsString
+            brokerList += current
+        }
+
+        val brokers = ("brokers", brokerList.toList)
+
+        System.setProperty("java.security.auth.login.config", "")
+        setMessageHubSecurityConfiguration(user._2, password._2)
+
+        Map(user, password, kafka_admin_url, api_key, brokers, security_protocol, keySerializer, valueSerializer)
+    }
+
+    private def setMessageHubSecurityConfiguration(user: String, password: String) = {
+        val map = new HashMap[String, String]()
+        map.put("serviceName", "kafka")
+        map.put("username", user)
+        map.put("password", password)
+        Configuration.setConfiguration(new Configuration()
+        {
+            def getAppConfigurationEntry(name: String): Array[AppConfigurationEntry] = Array(
+    	          new AppConfigurationEntry (
+    	              "com.ibm.messagehub.login.MessageHubLoginModule",
+     			          AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, map))
+        })
+    }
+}


### PR DESCRIPTION
Consolidate all MH initialization into a new KafkaUtils class.

Check the resulting activations to make sure that one of them actually contains the keys and values for the message produced by the test. This protects against running the test concurrently on the same MH queue.