### PR TITLE
Use blocking invokes when running messageHubProduce

### DIFF
--- a/tests/src/test/scala/system/health/BasicHealthTest.scala
+++ b/tests/src/test/scala/system/health/BasicHealthTest.scala
@@ -96,7 +96,7 @@ class BasicHealthTest
                 "kafka_brokers_sasl" -> kafkaUtils.getAsJson("brokers"),
                 "topic" -> topic.toJson,
                 "key" -> key.toJson,
-                "value" -> currentTime.toJson))) {
+                "value" -> currentTime.toJson), blocking=true)) {
                     _.response.success shouldBe true
                 }
 

--- a/tests/src/test/scala/system/packages/MessageHubFeedTests.scala
+++ b/tests/src/test/scala/system/packages/MessageHubFeedTests.scala
@@ -173,7 +173,7 @@ class MessageHubFeedTests
               "kafka_brokers_sasl" -> kafkaUtils.getAsJson("brokers"),
               "topic" -> topic.toJson,
               "key" -> key.toJson,
-              "value" -> currentTime.toJson))) {
+              "value" -> currentTime.toJson), blocking=true)) {
               _.response.success shouldBe true
           }
 

--- a/tests/src/test/scala/system/packages/MessageHubProduceTests.scala
+++ b/tests/src/test/scala/system/packages/MessageHubProduceTests.scala
@@ -169,7 +169,7 @@ class MessageHubProduceTests
             val encodedMessage = Base64.getEncoder.encodeToString(decodedMessage.getBytes(StandardCharsets.UTF_8))
             val base64ValueParams = validParameters + ("base64DecodeValue" -> true.toJson) + ("value" -> encodedMessage.toJson)
 
-            withActivation(wsk.activation, wsk.action.invoke(s"$messagingPackage/$messageHubProduce", base64ValueParams)) {
+            withActivation(wsk.activation, wsk.action.invoke(s"$messagingPackage/$messageHubProduce", base64ValueParams, blocking=true)) {
                 activation =>
                     activation.response.success shouldBe true
             }
@@ -223,7 +223,7 @@ class MessageHubProduceTests
             val encodedKey = Base64.getEncoder.encodeToString(decodedKey.getBytes(StandardCharsets.UTF_8))
             val base64ValueParams = validParameters + ("base64DecodeKey" -> true.toJson) + ("key" -> encodedKey.toJson)
 
-            withActivation(wsk.activation, wsk.action.invoke(s"$messagingPackage/$messageHubProduce", base64ValueParams)) {
+            withActivation(wsk.activation, wsk.action.invoke(s"$messagingPackage/$messageHubProduce", base64ValueParams, blocking=true)) {
                 activation =>
                     activation.response.success shouldBe true
             }


### PR DESCRIPTION
These tests really should not proceed until it is known that the produce action fully completed.