### PR TITLE
During tests, give the consumer time to initialize

### DIFF
--- a/tests/src/test/scala/system/health/BasicHealthTest.scala
+++ b/tests/src/test/scala/system/health/BasicHealthTest.scala
@@ -57,6 +57,8 @@ class BasicHealthTest
     val messageHubFeed = "messageHubFeed"
     val messageHubProduce = "messageHubProduce"
 
+    val consumerInitTime = 10000 // ms
+
     val kafkaUtils = new KafkaUtils
 
     behavior of "Message Hub feed"
@@ -85,9 +87,9 @@ class BasicHealthTest
                     activation.response.success shouldBe true
             }
 
-            // It takes a moment for the consumer to fully initialize. We choose 4 seconds
-            // as a temporary length of time to wait for.
-            Thread.sleep(4000)
+            // It takes a moment for the consumer to fully initialize.
+            println("Giving the consumer a moment to get ready")
+            Thread.sleep(consumerInitTime)
 
             // key to use for the produced message
             val key = "TheKey"

--- a/tests/src/test/scala/system/packages/MessageHubFeedTests.scala
+++ b/tests/src/test/scala/system/packages/MessageHubFeedTests.scala
@@ -59,6 +59,8 @@ class MessageHubFeedTests
   val messageHubFeed = "messageHubFeed"
   val messageHubProduce = "messageHubProduce"
 
+  val consumerInitTime = 10000 // ms
+
   val kafkaUtils = new KafkaUtils
 
   implicit val wskprops = WskProps()
@@ -160,9 +162,9 @@ class MessageHubFeedTests
                   activation.response.success shouldBe true
           }
 
-          // It takes a moment for the consumer to fully initialize. We choose 4 seconds
-          // as a temporary length of time to wait for.
-          Thread.sleep(4000)
+          // It takes a moment for the consumer to fully initialize.
+          println("Giving the consumer a moment to get ready")
+          Thread.sleep(consumerInitTime)
 
           // key to use for the produced message
           val key = "TheKey"

--- a/tests/src/test/scala/system/packages/MessageHubProduceTests.scala
+++ b/tests/src/test/scala/system/packages/MessageHubProduceTests.scala
@@ -59,6 +59,8 @@ class MessageHubProduceTests
     val messageHubFeed = "messageHubFeed"
     val messageHubProduce = "messageHubProduce"
 
+    val consumerInitTime = 10000 // ms
+
     val kafkaUtils = new KafkaUtils
 
     // these parameter values are 100% valid and should work as-is
@@ -166,6 +168,10 @@ class MessageHubProduceTests
                     activation.response.success shouldBe true
             }
 
+            // It takes a moment for the consumer to fully initialize.
+            println("Giving the consumer a moment to get ready")
+            Thread.sleep(consumerInitTime)
+
             // produce message
             val decodedMessage = "This will be base64 encoded"
             val encodedMessage = Base64.getEncoder.encodeToString(decodedMessage.getBytes(StandardCharsets.UTF_8))
@@ -221,6 +227,10 @@ class MessageHubProduceTests
                     // should be successful
                     activation.response.success shouldBe true
             }
+
+            // It takes a moment for the consumer to fully initialize.
+            println("Giving the consumer a moment to get ready")
+            Thread.sleep(consumerInitTime)
 
             // produce message
             val decodedKey = "This will be base64 encoded"


### PR DESCRIPTION
I can take several seconds for the consumer to fully initialize before it is ready to consume new messages. Wait a (hopefully) excessive amount of time to help guarantee the consumer is ready before producing a message.