### PR TITLE
Use CouchDB view instead of retrieving all docs

### DIFF
--- a/provider/app.py
+++ b/provider/app.py
@@ -177,7 +177,11 @@ def restoreTriggers():
     for triggerDoc in database.triggers():
         triggerFQN = triggerDoc['_id']
         logging.debug('Restoring trigger {}'.format(triggerFQN))
-        createAndRunConsumer(triggerFQN, triggerDoc, record=False)
+
+        try:
+            createAndRunConsumer(triggerFQN, triggerDoc, record=False)
+        except:
+            logging.warn('Skipping consumer due to caught exception: {}'.format(triggerDoc))
 
 
 def getMissingPostFields(fields):


### PR DESCRIPTION
This strategy is more robust than fetching all docs and just assuming they represent triggers.

This change has a couple pieces:
- during DB migration, if needed, add a view that only contains valid trigger docs
- in Database.triggers() use the new view to retrieve just the triggers

This approach works in both cases where the DB does and does not already exist.