### PR TITLE
Allow health test to specify an option trigger name suffix

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -15,6 +15,7 @@ def commonConfiguration = {
   systemProperty 'testthreads', System.getProperty('testthreads', '1')
   systemProperty 'host', System.getProperty('host', '')
   systemProperty 'port', System.getProperty('port', '')
+  systemProperty 'trigger.suffix', System.getProperty('trigger.suffix', '')
   testLogging {
     events "passed", "skipped", "failed"
     showStandardStreams = true
@@ -38,6 +39,7 @@ task stress(type: Test) {
 }
 
 task testHealth(type: Test) {
+  configure commonConfiguration
   systemProperty 'test.router', 'true'
   include 'system/health/**'
 }
@@ -52,5 +54,3 @@ dependencies {
 tasks.withType(ScalaCompile) {
   scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
 }
-
-

--- a/tests/src/test/scala/system/health/BasicHealthTest.scala
+++ b/tests/src/test/scala/system/health/BasicHealthTest.scala
@@ -73,7 +73,13 @@ class BasicHealthTest
 
     it should "fire a trigger when a message is posted to message hub" in withAssetCleaner(wskprops) {
         val currentTime = s"${System.currentTimeMillis}"
-        val triggerName = "/_/BasicHealthTestTrigger"
+
+        val baseTriggerName = "/_/BasicHealthTestTrigger"
+
+        val triggerName = System.getProperty("trigger.suffix") match {
+            case suffix if suffix != "" => s"${baseTriggerName}-${suffix}"
+            case _ => baseTriggerName
+        }
 
         (wp, assetHelper) =>
             val result = wsk.trigger.get(triggerName, expectedExitCode = DONTCARE_EXIT)


### PR DESCRIPTION
This makes it easier to utilize the trigger reuse that happens in the test.